### PR TITLE
未設定のプレースホルダーに値を設定

### DIFF
--- a/src/test/resources/please/change/me/common/captcha/message.config
+++ b/src/test/resources/please/change/me/common/captcha/message.config
@@ -1,2 +1,0 @@
-#メッセージを一括ロードするか否か(falseの場合はオンデマンドロード)
-loadMessageOnStartUp = false;

--- a/src/test/resources/please/change/me/common/captcha/message.config
+++ b/src/test/resources/please/change/me/common/captcha/message.config
@@ -1,0 +1,2 @@
+#メッセージを一括ロードするか否か(falseの場合はオンデマンドロード)
+loadMessageOnStartUp = false;

--- a/src/test/resources/please/change/me/common/captcha/message.xml
+++ b/src/test/resources/please/change/me/common/captcha/message.xml
@@ -7,6 +7,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://tis.co.jp/nablarch/component-configuration  ../component-configuration.xsd">
 
+  <!-- メッセージ用設定値 -->
+  <config-file file="please/change/me/common/captcha/message.config" />
+
   <!-- 文字列リソースのロードモジュール -->
   <component name="stringResourceLoader"
       class="nablarch.core.message.BasicStringResourceLoader">

--- a/src/test/resources/please/change/me/common/captcha/message.xml
+++ b/src/test/resources/please/change/me/common/captcha/message.xml
@@ -7,9 +7,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://tis.co.jp/nablarch/component-configuration  ../component-configuration.xsd">
 
-  <!-- メッセージ用設定値 -->
-  <config-file file="please/change/me/common/captcha/message.config" />
-
   <!-- 文字列リソースのロードモジュール -->
   <component name="stringResourceLoader"
       class="nablarch.core.message.BasicStringResourceLoader">
@@ -28,8 +25,6 @@
   <component name="stringResourceCache"
       class="nablarch.core.cache.BasicStaticDataCache">
     <property name="loader" ref="stringResourceLoader" />
-    <!-- 初期ロード -->
-    <property name="loadOnStartup" value="${loadMessageOnStartUp}" />
   </component>
 
   <!-- 文字列リソースの保持クラス -->

--- a/src/test/resources/please/change/me/common/captcha/validation.config
+++ b/src/test/resources/please/change/me/common/captcha/validation.config
@@ -1,3 +1,6 @@
+# validation時に精査対象の値にnullを許可するか否か
+validationConvertorAllowNullValue=false
+
 #半角数字
 numeric=0123456789
 


### PR DESCRIPTION
## 背景
https://nablarch.atlassian.net/jira/software/c/projects/NAB/issues/NAB-396 の対応に伴い未設定のプレースホルダーに値を設定する必要が生じた。

## 行なったこと
- 未設定のプロパティに対する値の設定

## 確認したこと
- ユニットテストが動作すること